### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   link-asana-task:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -3,10 +3,12 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   checklist:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: freckle/commenter-action@main

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   checklist:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: freckle/commenter-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freckle/npm-package-template/security/code-scanning/2](https://github.com/freckle/npm-package-template/security/code-scanning/2)

The fix is to add an explicit `permissions` block to the workflow to control what the GITHUB_TOKEN can and cannot do. For this workflow, because it leverages `freckle/commenter-action` to comment on pull requests (presumably as part of review/checklist automation), the minimal necessary permission is `pull-requests: write` or, in some cases, `issues: write` (as PR comments are technically on issues in the GitHub model). Adding `permissions` at the job level (to the `checklist` job) is sufficient and avoids over-broadening other jobs in composite workflows. Insert the following under the job name (`checklist:`) and before `runs-on:`. If you need to support both pull requests and issues, you can specify both as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
